### PR TITLE
fix readme

### DIFF
--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -271,7 +271,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install uswitch/kiam --name my-release \
-  --set=extraArgs.base-role-arn=arn:aws:iam::0123456789:role/,extraArgs.default-role=kube2iam-default,host.iptables=true,host.interface=cbr0
+  --set=extraArgs.base-role-arn=arn:aws:iam::0123456789:role/,extraArgs.default-role=kube2iam-default,agent.host.iptables=true,agent.host.interface=cbr0
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,


### PR DESCRIPTION
Helm readme has missing agent prefix when settings iptables and network interface.